### PR TITLE
Return Drip's unique user ID as the UID, instead of the client id.

### DIFF
--- a/lib/omniauth/strategies/drip.rb
+++ b/lib/omniauth/strategies/drip.rb
@@ -38,6 +38,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= JSON.parse(access_token.get("/v2/accounts").body)
       end
+
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
     end
   end
 end

--- a/lib/omniauth/strategies/drip.rb
+++ b/lib/omniauth/strategies/drip.rb
@@ -17,7 +17,7 @@ module OmniAuth
         :token_url => 'https://www.getdrip.com/oauth/token'
       }
 
-      uid { access_token.client.id }
+      uid { raw_info['accounts'][0]['id'] }
 
       info do
         {

--- a/spec/omniauth/strategies/drip_spec.rb
+++ b/spec/omniauth/strategies/drip_spec.rb
@@ -26,4 +26,13 @@ describe OmniAuth::Strategies::Drip do
     end
   end
 
+  context 'uid' do
+    before :each do
+      subject.stub(:raw_info) { { 'accounts' => [{ 'id' => '123' }] } }
+    end
+
+    it 'returns the id from raw_info' do
+      subject.uid.should eq('123')
+    end
+  end
 end


### PR DESCRIPTION
Solves Issue #4 and correctly returns the drip user's id as the `uid`. 